### PR TITLE
Refactor getActiveScheduledMaintenances to return objects in UTC format

### DIFF
--- a/force-app/main/default/classes/ScheduledMaintenanceService.cls
+++ b/force-app/main/default/classes/ScheduledMaintenanceService.cls
@@ -1,7 +1,7 @@
 public with sharing class ScheduledMaintenanceService {
     // Retrieves active scheduled maintenances applicable to the specified app context.
     @AuraEnabled(cacheable=false)
-    public static List<Scheduled_Maintenance__c> getActiveScheduledMaintenances(String appContext) {
+    public static List<Object> getActiveScheduledMaintenances(String appContext) {
         // Record the current date and time.
         DateTime now = DateTime.now();
         System.debug('Current DateTime used: ' + now);
@@ -34,10 +34,26 @@ public with sharing class ScheduledMaintenanceService {
             List<Scheduled_Maintenance__c> records = Database.query(queryString);
             // Log the number of records fetched.
             System.debug('Fetched records: ' + records.size());
-            return records;
+            // Convert date fields to UTC ISO strings for each record
+            List<Map<String, Object>> result = new List<Map<String, Object>>();
+            for (Scheduled_Maintenance__c rec : records) {
+                Map<String, Object> m = new Map<String, Object>();
+                m.put('Id', rec.Id);
+                m.put('Name', rec.Name);
+                m.put('Start_Date_Time__c', rec.Start_Date_Time__c != null ? rec.Start_Date_Time__c.formatGMT('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'') : null);
+                m.put('End_Date_Time__c', rec.End_Date_Time__c != null ? rec.End_Date_Time__c.formatGMT('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'') : null);
+                m.put('Subject__c', rec.Subject__c);
+                m.put('Description__c', rec.Description__c);
+                m.put('Alert_Frequency__c', rec.Alert_Frequency__c);
+                m.put('Start_Date_with_Buffer__c', rec.Start_Date_with_Buffer__c != null ? rec.Start_Date_with_Buffer__c.formatGMT('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'') : null);
+                m.put('Dismissible__c', rec.Dismissible__c);
+                m.put('Applicable_Apps__c', rec.Applicable_Apps__c);
+                result.add(m);
+            }
+            return (List<Object>)result;
         } catch (Exception ex) {
             System.debug('Exception during Database.query: ' + ex.getMessage());
-            return new List<Scheduled_Maintenance__c>();
+            return new List<Object>();
         }
     }
 

--- a/force-app/main/default/classes/ScheduledMaintenanceServiceTest.cls
+++ b/force-app/main/default/classes/ScheduledMaintenanceServiceTest.cls
@@ -53,42 +53,47 @@ public class ScheduledMaintenanceServiceTest {
         Test.startTest();
 
         // Test with no app context (should include only 'System')
-        List<Scheduled_Maintenance__c> results = ScheduledMaintenanceService.getActiveScheduledMaintenances(null);
+        List<Object> results = ScheduledMaintenanceService.getActiveScheduledMaintenances(null);
         System.debug('Results for no context: ' + results);
-        for (Scheduled_Maintenance__c maint : results) {
-            System.debug('Record for no context: ' + maint + ', Applicable_Apps__c: ' + maint.Applicable_Apps__c);
+        for (Object o : results) {
+            Map<String, Object> maint = (Map<String, Object>)o;
+            System.debug('Record for no context: ' + maint + ', Applicable_Apps__c: ' + maint.get('Applicable_Apps__c'));
         }
         System.assertEquals(1, results.size(), 'There should be 1 active maintenance record for System');
 
         // Test with app context 'System'
         results = ScheduledMaintenanceService.getActiveScheduledMaintenances('System');
         System.debug('Results for System context: ' + results);
-        for (Scheduled_Maintenance__c maint : results) {
-            System.debug('Record for System context: ' + maint + ', Applicable_Apps__c: ' + maint.Applicable_Apps__c);
+        for (Object o : results) {
+            Map<String, Object> maint = (Map<String, Object>)o;
+            System.debug('Record for System context: ' + maint + ', Applicable_Apps__c: ' + maint.get('Applicable_Apps__c'));
         }
         System.assertEquals(1, results.size(), 'There should be 1 active maintenance record for System');
 
         // Test with app context 'CRM'
         results = ScheduledMaintenanceService.getActiveScheduledMaintenances('CRM');
         System.debug('Results for CRM context: ' + results);
-        for (Scheduled_Maintenance__c maint : results) {
-            System.debug('Record for CRM context: ' + maint + ', Applicable_Apps__c: ' + maint.Applicable_Apps__c);
+        for (Object o : results) {
+            Map<String, Object> maint = (Map<String, Object>)o;
+            System.debug('Record for CRM context: ' + maint + ', Applicable_Apps__c: ' + maint.get('Applicable_Apps__c'));
         }
         System.assertEquals(1, results.size(), 'There should be 1 active maintenance records for CRM');
 
         // Test with app context 'SMS'
         results = ScheduledMaintenanceService.getActiveScheduledMaintenances('SMS');
         System.debug('Results for SMS context: ' + results);
-        for (Scheduled_Maintenance__c maint : results) {
-            System.debug('Record for SMS context: ' + maint + ', Applicable_Apps__c: ' + maint.Applicable_Apps__c);
+        for (Object o : results) {
+            Map<String, Object> maint = (Map<String, Object>)o;
+            System.debug('Record for SMS context: ' + maint + ', Applicable_Apps__c: ' + maint.get('Applicable_Apps__c'));
         }
         System.assertEquals(2, results.size(), 'There should be 2 active maintenance record for SMS');
 
         // Test with app context 'PSA'
         results = ScheduledMaintenanceService.getActiveScheduledMaintenances('PSA');
         System.debug('Results for PSA context: ' + results);
-        for (Scheduled_Maintenance__c maint : results) {
-            System.debug('Record for PSA context: ' + maint + ', Applicable_Apps__c: ' + maint.Applicable_Apps__c);
+        for (Object o : results) {
+            Map<String, Object> maint = (Map<String, Object>)o;
+            System.debug('Record for PSA context: ' + maint + ', Applicable_Apps__c: ' + maint.get('Applicable_Apps__c'));
         }
         System.assertEquals(2, results.size(), 'There should be 2 active maintenance record for PSA');
 

--- a/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.js
+++ b/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.js
@@ -51,8 +51,9 @@ export default class ScheduledMaintenanceComponent extends NavigationMixin(Light
         this.scheduledMaintenances = data.filter(record => this.shouldShowAlert(record, now))
             .map(record => ({
                 ...record,
-                Start_Date_Time__c: this.formatDateTime(record.Start_Date_Time__c),
-                End_Date_Time__c: this.formatDateTime(record.End_Date_Time__c),
+                // Always parse as UTC
+                Start_Date_Time__c: this.formatDateTimeUTC(record.Start_Date_Time__c),
+                End_Date_Time__c: this.formatDateTimeUTC(record.End_Date_Time__c),
                 Dismissible: this.calculateDismissible(record, now),
                 Subject: record.Subject__c,
                 BadgeLabel: !record.Dismissible__c ? (record.Applicable_Apps__c.includes('System') ? 'Requires System Lock' : 'Requires App Lock') : ''
@@ -62,8 +63,8 @@ export default class ScheduledMaintenanceComponent extends NavigationMixin(Light
         }
         // Check maintenance status
         data.some(record => {
-            const startDate = new Date(record.Start_Date_Time__c);
-            const endDate = new Date(record.End_Date_Time__c);
+            const startDate = this.parseUTCDate(record.Start_Date_Time__c);
+            const endDate = this.parseUTCDate(record.End_Date_Time__c);
             const isCurrent = now >= startDate && now <= endDate;
 
             if (isCurrent) {
@@ -106,13 +107,13 @@ export default class ScheduledMaintenanceComponent extends NavigationMixin(Light
     updateDismissibleStatus() {
         const now = new Date();
         this.isFullLock = this.scheduledMaintenances.some(record => {
-            const startDate = new Date(record.Start_Date_Time__c);
-            const endDate = new Date(record.End_Date_Time__c);
+            const startDate = this.parseUTCDate(record.Start_Date_Time__c);
+            const endDate = this.parseUTCDate(record.End_Date_Time__c);
             return record.Applicable_Apps__c.includes('System') && now >= startDate && now <= endDate && !record.Dismissible__c;
         });
         this.isDismissible = !this.isFullLock && this.scheduledMaintenances.every(record => {
-            const startDate = new Date(record.Start_Date_Time__c);
-            const endDate = new Date(record.End_Date_Time__c);
+            const startDate = this.parseUTCDate(record.Start_Date_Time__c);
+            const endDate = this.parseUTCDate(record.End_Date_Time__c);
             return now < startDate || now > endDate || record.Dismissible__c;
         });
         console.log('Is Dismissible: ' + this.isDismissible);
@@ -124,8 +125,8 @@ export default class ScheduledMaintenanceComponent extends NavigationMixin(Light
 
     // Determines if a record is dismissible based on its start and end times.
     calculateDismissible(record, now) {
-        const startDate = new Date(record.Start_Date_Time__c);
-        const endDate = new Date(record.End_Date_Time__c);
+        const startDate = this.parseUTCDate(record.Start_Date_Time__c);
+        const endDate = this.parseUTCDate(record.End_Date_Time__c);
         if (now >= startDate && now <= endDate && !record.Dismissible__c) {
             return false; 
         }
@@ -166,13 +167,13 @@ export default class ScheduledMaintenanceComponent extends NavigationMixin(Light
     
     // Determines if an alert should be shown based on its timing and dismissibility.
     shouldShowAlert(record, currentDate) {
-        const startDate = new Date(record.Start_Date_Time__c);
-        const endDate = new Date(record.End_Date_Time__c);
+        const startDate = this.parseUTCDate(record.Start_Date_Time__c);
+        const endDate = this.parseUTCDate(record.End_Date_Time__c);
         if (currentDate >= startDate && currentDate <= endDate && !record.Dismissible__c) {
             return true;
         }
         const lastDismissedDate = localStorage.getItem(`maintenanceDismissed_${record.Id}`);
-        const lastDismissed = lastDismissedDate ? new Date(lastDismissedDate) : null;
+        const lastDismissed = lastDismissedDate ? this.parseUTCDate(lastDismissedDate) : null;
         return !lastDismissed || this.frequencyAllowsAlert(record.Alert_Frequency__c, lastDismissed, currentDate);
     }
     // Determines if a maintenance alert should be repeated based on its frequency and the last dismissal date.
@@ -183,19 +184,30 @@ export default class ScheduledMaintenanceComponent extends NavigationMixin(Light
             case 'Daily':
                 return !lastDismissed || lastDismissed.toISOString().slice(0, 10) !== currentDate.toISOString().slice(0, 10);
             case 'Weekly':
-                let oneWeekAgo = new Date(currentDate);
-                oneWeekAgo.setDate(currentDate.getDate() - 7);
+                let oneWeekAgo = new Date(Date.UTC(currentDate.getUTCFullYear(), currentDate.getUTCMonth(), currentDate.getUTCDate() - 7));
                 return !lastDismissed || lastDismissed < oneWeekAgo;
             default:
                 return true;
         }
     }
-    // Formats date and time strings for display.
-    formatDateTime(dateTime) {
+    // Formats date and time strings for display (UTC)
+    formatDateTimeUTC(dateTime) {
+        if (!dateTime) return '';
+        const d = this.parseUTCDate(dateTime);
         return new Intl.DateTimeFormat('en-US', {
             year: '2-digit', month: '2-digit', day: '2-digit',
-            hour: '2-digit', minute: '2-digit', hour12: true
-        }).format(new Date(dateTime));
+            hour: '2-digit', minute: '2-digit', hour12: true,
+            timeZone: 'UTC'
+        }).format(d);
+    }
+
+    // Parse a date string as UTC (expects ISO 8601 with Z)
+    parseUTCDate(dateString) {
+        if (!dateString) return null;
+        // If already a Date, return as is
+        if (dateString instanceof Date) return dateString;
+        // Always parse as UTC
+        return new Date(dateString);
     }
     
 }


### PR DESCRIPTION
Update the `getActiveScheduledMaintenances` method to return a list of objects instead of scheduled maintenance records, ensuring date handling is in UTC format. Adjust related tests to accommodate these changes.

Fixes #12