### PR TITLE
Update scheduled maintenance display to use formatted local date and time

### DIFF
--- a/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.html
+++ b/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.html
@@ -28,8 +28,8 @@
                                 <lightning-accordion-section key={maint.Id} name={maint.Id} label={maint.Subject}>
                                     <div class="slds-box slds-theme_default slds-var-m-bottom_small">
                                         <p class="slds-p-bottom_small"><strong>Description:</strong> {maint.Description__c}</p>
-                                        <p><strong>Start:</strong> {maint.Start_Date_Time__c}</p>
-                                        <p><strong>End:</strong> {maint.End_Date_Time__c}</p>
+                                        <p><strong>Start:</strong> {maint.startDisplay}</p>
+                                        <p><strong>End:</strong> {maint.endDisplay}</p>
                                         <div class="slds-m-top_x-small">
                                             <template if:false={maint.Dismissible__c}>
                                                 <lightning-badge label={maint.BadgeLabel} class="slds-m-left_xx-small slds-m-top_x-small"></lightning-badge>
@@ -46,8 +46,8 @@
                             <div key={maint.Id} class="slds-box slds-theme_default slds-var-m-bottom_small">
                                 <h2 class="slds-text-heading_small slds-var-m-bottom_small"><strong>{maint.Subject}</strong></h2>
                                 <p class="slds-p-bottom_small"><strong>Description:</strong> {maint.Description__c}</p>
-                                <p><strong>Start:</strong> {maint.Start_Date_Time__c}</p>
-                                <p><strong>End:</strong> {maint.End_Date_Time__c}</p>
+                                <p><strong>Start:</strong> {maint.startDisplay}</p>
+                                <p><strong>End:</strong> {maint.endDisplay}</p>
                                 <template if:false={maint.Dismissible__c}>
                                     <lightning-badge label={maint.BadgeLabel} class="slds-m-left_xx-small slds-m-top_x-small"></lightning-badge>
                                 </template>

--- a/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.js
+++ b/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.js
@@ -68,8 +68,9 @@ export default class ScheduledMaintenanceComponent extends NavigationMixin(Light
         this.scheduledMaintenances = data.filter(record => this.shouldShowAlert(record, now))
             .map(record => ({
                 ...record,
-                Start_Date_Time__c: this.formatDateTimeLocal(record.Start_Date_Time__c, userLocale, userTimeZone),
-                End_Date_Time__c: this.formatDateTimeLocal(record.End_Date_Time__c, userLocale, userTimeZone),
+                // Preserve raw ISO values for logic
+                startDisplay: this.formatDateTimeLocal(record.Start_Date_Time__c, userLocale, userTimeZone),
+                endDisplay: this.formatDateTimeLocal(record.End_Date_Time__c, userLocale, userTimeZone),
                 Dismissible: this.calculateDismissible(record, now),
                 Subject: record.Subject__c,
                 BadgeLabel: !record.Dismissible__c ? (record.Applicable_Apps__c.includes('System') ? 'Requires System Lock' : 'Requires App Lock') : ''


### PR DESCRIPTION
Improve the display of scheduled maintenance by formatting the start and end times to the user's local date and time. This change enhances clarity and user experience.

Fixes #7