### PR TITLE
Add CSS class for multi-line text formatting in maintenance descriptions

### DIFF
--- a/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.css
+++ b/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.css
@@ -1,0 +1,3 @@
+.multi-line {
+    white-space: pre-line;
+}

--- a/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.html
+++ b/force-app/main/default/lwc/scheduledMaintenanceComponent/scheduledMaintenanceComponent.html
@@ -37,7 +37,7 @@
                                     <template for:each={inProgressMaintenances} for:item="maint">
                                         <div key={maint.Id} class="slds-box slds-theme_default slds-var-m-bottom_small">
                                             <h2 class="slds-text-heading_small slds-var-m-bottom_small"><strong>{maint.Subject}</strong></h2>
-                                            <p class="slds-p-bottom_small"><strong>Description:</strong> {maint.Description__c}</p>
+                                            <p class="slds-p-bottom_small multi-line"><strong>Description:</strong> {maint.Description__c}</p>
                                             <p><strong>Start:</strong> {maint.startDisplay}</p>
                                             <p><strong>End:</strong> {maint.endDisplay}</p>
                                             <template if:false={maint.Dismissible__c}>
@@ -64,7 +64,7 @@
                                     <template for:each={upcomingMaintenances} for:item="maint">
                                         <div key={maint.Id} class="slds-box slds-theme_default slds-var-m-bottom_small">
                                             <h2 class="slds-text-heading_small slds-var-m-bottom_small"><strong>{maint.Subject}</strong></h2>
-                                            <p class="slds-p-bottom_small"><strong>Description:</strong> {maint.Description__c}</p>
+                                            <p class="slds-p-bottom_small multi-line"><strong>Description:</strong> {maint.Description__c}</p>
                                             <p><strong>Start:</strong> {maint.startDisplay}</p>
                                             <p><strong>End:</strong> {maint.endDisplay}</p>
                                             <template if:false={maint.Dismissible__c}>


### PR DESCRIPTION
Introduce a CSS class to enable multi-line text formatting for maintenance descriptions, enhancing readability. This change applies to both in-progress and upcoming maintenance sections. No issues are fixed with this update.

